### PR TITLE
Add required provider for Terraform

### DIFF
--- a/backend.tf
+++ b/backend.tf
@@ -1,4 +1,13 @@
 terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0.0"
+    }
+  }
+}
+
+terraform {
   backend "s3" {
     bucket         = "immune-g2-s3-01"
     key            = "terraform/state/production/terraform.tfstate"


### PR DESCRIPTION
Introduce the AWS provider configuration for Terraform to ensure compatibility with the specified version.