### PR TITLE
Update AWS Secrets Manager secret name for deployment v2

### DIFF
--- a/secretmanager.tf
+++ b/secretmanager.tf
@@ -1,4 +1,4 @@
 # Secret Manager Secret
 resource "aws_secretsmanager_secret" "immune-g2-secret-01" {
-  name = "/api/rds/immune-g2-rds-credentials"
+  name = "/api/rds/immune-g2-rds-credentials-v2"
 }


### PR DESCRIPTION
Change the name of the AWS Secrets Manager secret to reflect the new version for deployment purposes.